### PR TITLE
feat: ajout du support pour le prévisionnel dans la vue semestre

### DIFF
--- a/back/src/ApiDto/PersonnelsContraintes.php
+++ b/back/src/ApiDto/PersonnelsContraintes.php
@@ -3,7 +3,6 @@
 namespace App\ApiDto;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;

--- a/back/src/Entity/Previsionnel/Previsionnel.php
+++ b/back/src/Entity/Previsionnel/Previsionnel.php
@@ -10,7 +10,6 @@ use ApiPlatform\Metadata\Patch;
 use App\Entity\Edt\EdtProgression;
 use App\Entity\Scolarite\ScolEnseignement;
 use App\Entity\Structure\StructureAnneeUniversitaire;
-use App\Entity\Structure\StructureSemestre;
 use App\Entity\Users\Personnel;
 use App\Filter\PrevisionnelFilter;
 use App\Repository\Previsionnel\PrevisionnelRepository;
@@ -54,6 +53,7 @@ class Previsionnel
     private ?bool $referent = null;
 
     #[ORM\Column(type: Types::JSON)]
+    #[Groups(['previsionnel:read'])]
     private array $heures = [];
 
     #[ORM\Column]

--- a/back/src/Entity/Scolarite/ScolEnseignement.php
+++ b/back/src/Entity/Scolarite/ScolEnseignement.php
@@ -32,11 +32,11 @@ class ScolEnseignement
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['semestre:read:full'])]
+    #[Groups(['semestre:read:full', 'previsionnel:read'])]
     private ?string $libelle = null;
 
     #[ORM\Column(length: 25, nullable: true)]
-    #[Groups(['semestre:read:full'])]
+    #[Groups(['semestre:read:full', 'previsionnel:read'])]
     private ?string $libelle_court = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
@@ -52,7 +52,7 @@ class ScolEnseignement
     private ?string $motsCles = null;
 
     #[ORM\Column(length: 20, nullable: true)]
-    #[Groups(['semestre:read:full'])]
+    #[Groups(['semestre:read:full', 'previsionnel:read'])]
     private ?string $codeEnseignement = null;
 
     #[ORM\Column]
@@ -63,7 +63,7 @@ class ScolEnseignement
     private array $heures = [];
 
     #[ORM\Column(type: 'string', enumType: TypeEnseignementEnum::class)]
-    #[Groups(['semestre:read:full'])]
+    #[Groups(['semestre:read:full', 'previsionnel:read'])]
     private TypeEnseignementEnum $type = TypeEnseignementEnum::TYPE_RESSOURCE;
 
     #[ORM\Column]

--- a/back/src/Entity/Users/Personnel.php
+++ b/back/src/Entity/Users/Personnel.php
@@ -6,9 +6,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
-use ApiPlatform\Metadata\Put;
 use App\Entity\Edt\EdtEvent;
-use App\Entity\Edt\EdtProgression;
 use App\Entity\Etudiant\EtudiantAbsence;
 use App\Entity\Previsionnel\Previsionnel;
 use App\Entity\Scolarite\ScolEvaluation;
@@ -60,7 +58,7 @@ class Personnel implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    #[Groups(['personnel:read', 'structure_departement_personnel:read'])]
+    #[Groups(['personnel:read', 'structure_departement_personnel:read', 'previsionnel:read'])]
     private ?int $id = null;
 
     #[ORM\Column(length: 75)]
@@ -79,11 +77,11 @@ class Personnel implements UserInterface, PasswordAuthenticatedUserInterface
     private array $roles = [];
 
     #[ORM\Column(length: 75)]
-    #[Groups(['personnel:read', 'structure_departement_personnel:read'])]
+    #[Groups(['personnel:read', 'structure_departement_personnel:read', 'previsionnel:read'])]
     private string $prenom;
 
     #[ORM\Column(length: 75)]
-    #[Groups(['personnel:read', 'structure_departement_personnel:read'])]
+    #[Groups(['personnel:read', 'structure_departement_personnel:read', 'previsionnel:read'])]
     private string $nom;
 
     #[ORM\Column(length: 255, nullable: true)]
@@ -690,7 +688,7 @@ class Personnel implements UserInterface, PasswordAuthenticatedUserInterface
         return self::STATUT[$this->statut] ?? null;
     }
 
-    #[Groups(['personnel:read', 'structure_departement_personnel:read'])]
+    #[Groups(['personnel:read', 'structure_departement_personnel:read', 'previsionnel:read'])]
     public function getDisplay(): string
     {
         return $this->getPrenom() . ' ' . $this->getNom();

--- a/front/apps/intranet/components.d.ts
+++ b/front/apps/intranet/components.d.ts
@@ -37,6 +37,7 @@ declare module 'vue' {
     InputText: typeof import('primevue/inputtext')['default']
     Menu: typeof import('primevue/menu')['default']
     Message: typeof import('primevue/message')['default']
+    MultiSelect: typeof import('primevue/multiselect')['default']
     PanelMenu: typeof import('primevue/panelmenu')['default']
     Pn: typeof import('./src/components/Administration/Pn.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/front/packages/common-requests/structure_services/previsionnelService.js
+++ b/front/packages/common-requests/structure_services/previsionnelService.js
@@ -5,4 +5,23 @@ const getSemestrePreviService = async (semestreId) => {
     return response.data.member;
 }
 
-export { getSemestrePreviService };
+const buildSemestrePreviService = async (previ) => {
+    const groupedPrevi = {};
+
+    previ.forEach(item => {
+        if (!item.enseignement) {
+            return; // Ignorer les éléments sans enseignement
+        }
+
+        const enseignementId = item.enseignement['@id'];
+        if (!groupedPrevi[enseignementId]) {
+            groupedPrevi[enseignementId] = { ...item, personnel: [] };
+        }
+
+        groupedPrevi[enseignementId].personnel.push(item.personnel);
+    });
+
+    return Object.values(groupedPrevi);
+}
+
+export { getSemestrePreviService, buildSemestrePreviService };

--- a/front/packages/common-stores/structure_stores/anneeUnivStore.js
+++ b/front/packages/common-stores/structure_stores/anneeUnivStore.js
@@ -1,6 +1,6 @@
 import {defineStore} from 'pinia'
 import {ref} from 'vue'
-import {getAllAnneesUniversitairesService, getCurrentAnneeUniversitaireService} from '@requests'
+import {getAllAnneesUniversitairesService, getCurrentAnneeUniversitaireService, getAnneeUniversitaireService } from '@requests'
 
 export const useAnneeUnivStore = defineStore('anneeUniv', () => {
 
@@ -23,9 +23,18 @@ export const useAnneeUnivStore = defineStore('anneeUniv', () => {
     }
   }
 
+  const getAnneeUniv = async (id) => {
+    try {
+      anneeUniv.value = await getAnneeUniversitaireService(id);
+    } catch (error) {
+      console.error('Error fetching user:', error);
+    }
+  };
+
   return {
     getAllAnneesUniv,
     getCurrentAnneeUniv,
+    getAnneeUniv,
     anneeUniv,
     anneesUniv
   };


### PR DESCRIPTION
Ajout des groupes 'previsionnel:read' dans plusieurs entités backend pour inclure les nouveaux champs nécessaires. Introduction d'un tableau regroupé des prévisionnels dans la vue Semestre côté front. Implémentation de nouvelles fonctions pour gérer et transformer les données prévisionnelles.