### PR TITLE
fix: corrige le filtre et les appels liés aux prévisionnels

### DIFF
--- a/back/src/Filter/PrevisionnelFilter.php
+++ b/back/src/Filter/PrevisionnelFilter.php
@@ -7,6 +7,7 @@ use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\Scolarite\ScolEnseignement;
 use App\Entity\Structure\StructureAnnee;
+use App\Entity\Structure\StructureAnneeUniversitaire;
 use App\Entity\Structure\StructureDepartement;
 use App\Entity\Structure\StructureDiplome;
 use App\Entity\Structure\StructureSemestre;
@@ -42,7 +43,8 @@ class PrevisionnelFilter extends AbstractFilter
 
         if ('anneeUniversitaire' === $property) {
             $queryBuilder
-                ->andWhere(sprintf('%s.anneeUniversitaire = :anneeUniversitaire', $alias))
+                ->join(sprintf('%s.anneeUniversitaire', $alias), 'au')
+                ->andWhere('au.id = :anneeUniversitaire')
                 ->setParameter('anneeUniversitaire', $value)
             ;
         }

--- a/front/apps/intranet/src/views/previsionnel/SemestreView.vue
+++ b/front/apps/intranet/src/views/previsionnel/SemestreView.vue
@@ -37,13 +37,12 @@ const getPrevi = async (semestreId) => {
     isLoadingPrevisionnel.value = true;
     await semestreStore.getSemestre(semestreId);
     semestreDetails.value = semestreStore.semestre;
-    // todo : récupérer le prévisionnel de l'année universitaire
 
-    previSemestre.value = await getSemestrePreviService(selectedSemestre.value.id, selectedAnneeUniv.id);
+    previSemestre.value = await getSemestrePreviService(selectedSemestre.value.id, selectedAnneeUniv.value.id);
     isLoadingPrevisionnel.value = false;
 
     previGrouped.value = await buildSemestrePreviService(previSemestre.value);
-    console.log('groupedPrevi', previGrouped.value);
+    // console.log('groupedPrevi', previGrouped.value);
   }
 };
 
@@ -69,8 +68,7 @@ watch([selectedSemestre, selectedAnneeUniv], async ([newSemestre, newAnneeUniv])
 </script>
 
 <template>
-  <div class="px-4 py-12">
-    <div>
+  <div class="px-4 py-12 flex flex-col gap-6">
       <div class="flex justify-between gap-10">
         <div class="flex gap-6 w-1/2">
           <SimpleSkeleton v-if="isLoadingSemestres" class="w-1/2" />
@@ -98,20 +96,20 @@ watch([selectedSemestre, selectedAnneeUniv], async ([newSemestre, newAnneeUniv])
         </div>
         <Button label="Saisir le prévisionnel" icon="pi pi-plus" />
       </div>
-      <ListSkeleton
-          v-if="isLoadingPrevisionnel"
-          class="mt-6"
-      />
+      <ListSkeleton v-if="isLoadingPrevisionnel" class="mt-6" />
       <div v-else>
-        <DataTable :value="previGrouped" tableStyle="min-width: 50rem">
-          <Column field="enseignement.codeEnseignement" header="Code"></Column>
-          <Column field="enseignement.libelle" header="Nom"></Column>
-          <Column field="enseignement.type" header="Type"></Column>
-          <Column field="personnel.length" header="Nb intervenants"></Column>
-          <Column field="heures" header="Heures"></Column>
+        <DataTable v-if="previGrouped?.length > 0" :value="previGrouped" tableStyle="min-width: 50rem">
+          <Column field="enseignement.codeEnseignement" header="Code" />
+          <Column field="enseignement.libelle" header="Nom" />
+          <Column field="enseignement.type" header="Type" />
+          <Column field="personnel.length" header="Nb intervenants" />
+          <Column field="heures" header="Heures" />
         </DataTable>
+
+        <Message v-else severity="error" icon="pi pi-times-circle">
+          Aucun prévisionnel pour cette année universitaire et ce semestre
+        </Message>
       </div>
-    </div>
   </div>
 </template>
 

--- a/front/packages/common-requests/structure_services/previsionnelService.js
+++ b/front/packages/common-requests/structure_services/previsionnelService.js
@@ -1,7 +1,7 @@
 import api from '@helpers/axios';
 
-const getSemestrePreviService = async (semestreId) => {
-    const response = await api.get(`/api/previsionnels?semestre=${semestreId}`);
+const getSemestrePreviService = async (semestreId, anneeUnivId) => {
+    const response = await api.get(`/api/previsionnels?anneeUniversitaire=${anneeUnivId}&semestre=${semestreId}`);
     return response.data.member;
 }
 


### PR DESCRIPTION
Ajoute la prise en compte de l'année universitaire dans les services, le filtre backend et la vue Semestre. Assure une meilleure précision des données récupérées et corrige des incohérences dans l'interface. Supprime également un console.log obsolète.